### PR TITLE
chore: integrate dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,9 @@ updates:
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
-      interval: "daily"
-      time: "01:30"
+      interval: "weekly"
+      day: "sunday"
+      time: "02:00"
       timezone: "Asia/Karachi"
     open-pull-requests-limit: 5
     reviewers:
@@ -14,7 +15,6 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
-      - "automated"
     groups:
       spring-boot:
         patterns:


### PR DESCRIPTION
## Description
Add Dependabot configuration to automatically manage Maven dependency updates. This introduces weekly automated pull requests for dependency updates, grouped by category (Spring Boot, testing frameworks, etc.) to reduce PR noise and ensure dependencies stay current and secure.

## Related Issue
Closes #3 

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Chore / Maintenance

## Checklist
- [x] My code follows the project's coding style.
- [ ] I've added tests where applicable.
- [ ] I've updated documentation (if needed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Enabled automated dependency updates for Maven on a weekly schedule (Sundays at 02:00 Asia/Karachi).
  - Capped concurrent update PRs at 5 and assigned a default reviewer.
  - Standardized commit messages with a deps(scope) prefix.
  - Applied a “dependencies” label to update PRs.
  - Grouped updates by Spring Boot, Testing, Jackson, and Hibernate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->