### PR TITLE
chore(ci): update GH actions aligning with Node 24

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "Friday"
+      day: "friday"
       time: "18:00"
       timezone: "Asia/Karachi"
     open-pull-requests-limit: 5
@@ -36,7 +36,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "Friday"
+      day: "friday"
       time: "19:00"
       timezone: "Asia/Karachi"
     open-pull-requests-limit: 1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,7 +39,7 @@ updates:
       day: "Friday"
       time: "19:00"
       timezone: "Asia/Karachi"
-    open-pull-requests-limit: 4
+    open-pull-requests-limit: 1
     reviewers:
       - "khawaja-abdullah"
     commit-message:
@@ -47,3 +47,7 @@ updates:
     labels:
       - "dependencies"
       - "ci"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "sunday"
-      time: "02:00"
+      day: "Friday"
+      time: "18:00"
       timezone: "Asia/Karachi"
     open-pull-requests-limit: 5
     reviewers:
@@ -32,3 +32,18 @@ updates:
         patterns:
           - "org.hibernate:*"
           - "jakarta.persistence:*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "Friday"
+      time: "19:00"
+      timezone: "Asia/Karachi"
+    open-pull-requests-limit: 4
+    reviewers:
+      - "khawaja-abdullah"
+    commit-message:
+      prefix: "deps(ci)"
+    labels:
+      - "dependencies"
+      - "ci"

--- a/.github/workflows/background-jobs.yml
+++ b/.github/workflows/background-jobs.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Restore previous state
-        uses: actions/cache@1bd1e32a3bd045305d15a201b44d32095cc27177 # v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: state.json
           key: issue-search-${{ github.run_id }}
@@ -23,7 +23,7 @@ jobs:
           ls -l state.json || echo "file does not exist yet"
           cat state.json || true
       - name: Set up JDK 21
-        uses: actions/setup-java@8df1039502715b7463328e27c9d7807187a74790 # v5.2.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -38,7 +38,7 @@ jobs:
           -Dspring-boot.run.arguments="--github.issue-search.job.execution-file=state.json"
       - name: Force save updated state
         if: always()
-        uses: actions/cache/save@1bd1e32a3bd045305d15a201b44d32095cc27177 # v5.0.5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: state.json
           key: issue-search-${{ github.run_id }}

--- a/.github/workflows/background-jobs.yml
+++ b/.github/workflows/background-jobs.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v6.0.2
       - name: Restore previous state
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@1bd1e32a3bd045305d15a201b44d32095cc27177 # v5.0.5
         with:
           path: state.json
           key: issue-search-${{ github.run_id }}
@@ -23,7 +23,7 @@ jobs:
           ls -l state.json || echo "file does not exist yet"
           cat state.json || true
       - name: Set up JDK 21
-        uses: actions/setup-java@v5.2.0
+        uses: actions/setup-java@8df1039502715b7463328e27c9d7807187a74790 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -38,7 +38,7 @@ jobs:
           -Dspring-boot.run.arguments="--github.issue-search.job.execution-file=state.json"
       - name: Force save updated state
         if: always()
-        uses: actions/cache/save@v5.0.5
+        uses: actions/cache/save@1bd1e32a3bd045305d15a201b44d32095cc27177 # v5.0.5
         with:
           path: state.json
           key: issue-search-${{ github.run_id }}

--- a/.github/workflows/background-jobs.yml
+++ b/.github/workflows/background-jobs.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Restore previous state
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.5
         with:
           path: state.json
           key: issue-search-${{ github.run_id }}
@@ -23,7 +23,7 @@ jobs:
           ls -l state.json || echo "file does not exist yet"
           cat state.json || true
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.2.0
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -38,7 +38,7 @@ jobs:
           -Dspring-boot.run.arguments="--github.issue-search.job.execution-file=state.json"
       - name: Force save updated state
         if: always()
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5.0.5
         with:
           path: state.json
           key: issue-search-${{ github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up JDK 21
-        uses: actions/setup-java@8df1039502715b7463328e27c9d7807187a74790 # v5.2.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -25,9 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up JDK 21
-        uses: actions/setup-java@8df1039502715b7463328e27c9d7807187a74790 # v5.2.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: '21'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v6.0.2
       - name: Set up JDK 21
-        uses: actions/setup-java@v5.2.0
+        uses: actions/setup-java@8df1039502715b7463328e27c9d7807187a74790 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -25,9 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v6.0.2
       - name: Set up JDK 21
-        uses: actions/setup-java@v5.2.0
+        uses: actions/setup-java@8df1039502715b7463328e27c9d7807187a74790 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: '21'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.2.0
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -25,9 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.2.0
         with:
           distribution: 'temurin'
           java-version: '21'


### PR DESCRIPTION
## Description
<!-- A minimal summary of what your changes are meant to accomplish -->
Updating GitHub actions versions post Node 20 deprecation.

## Related Issue
<!-- Link to any issue this PR closes (e.g. Closes #42) -->
N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Chore / Maintenance

## Checklist
- [x] My code follows the project’s coding style.
- [ ] I’ve added tests where applicable.
- [ ] I’ve updated documentation (if needed).